### PR TITLE
add in ph_num using textgrid files

### DIFF
--- a/variance-temp-solution/README.md
+++ b/variance-temp-solution/README.md
@@ -64,7 +64,19 @@ A universal monosyllabic phoneme system has "C(m)-V-C(n)" (m,n >= 0) phoneme pat
 
 ### 3.3 polysyllabic phoneme systems (English, Russian, etc.)
 
-We recommand this step be manually performed because word divisions cannot be infered from phoneme sequences in these phoneme systems.
+We recommand this step be **manually performed** because word divisions cannot be infered from phoneme sequences in these phoneme systems. However, we offer an automated option, please use at your own choice:  
+
+If you used the [no midi pipeline](https://github.com/openvpi/DiffSinger/blob/main/pipelines/no_midi_preparation.ipynb) to build your transcriptions and you have TextGrid files from Montreal Alignment or labelling that has words and phonemes in them the this **may** work for you
+
+
+The no_midi_preperation notebook pipeline adds in random SP at start and end of the textgrid data, this is taken into account but I recommend a manual sanity check after running this
+   ```bash
+   python textgrid_add_ph_num.py path/to/your/transcriptions.csv --textgrid_dir path/to/your/textgrid_dir --split_phones_file /path/to/split_on_phones.txt
+   ```
+an example [split_phones_file is here](split_on_phones.txt)
+
+   
+___
 
 > After finishing this step, the transcriptions.csv file can be directly used to train the phoneme duration predictor (it only needs rough MIDI sequences extracted from wave files). If you want to train a pitch predictor, you must finish the remaining steps as follows, otherwise the predictions will not be accurate.
 >

--- a/variance-temp-solution/README.md
+++ b/variance-temp-solution/README.md
@@ -70,7 +70,7 @@ If you used the [no midi pipeline](https://github.com/openvpi/DiffSinger/blob/ma
 
 
 The no_midi_preperation notebook pipeline adds in random SP at start and end of the textgrid data, this is taken into account but I recommend a manual sanity check after running this
-   ```bash
+```
    python textgrid_add_ph_num.py path/to/your/transcriptions.csv --textgrid_dir path/to/your/textgrid_dir --split_phones_file /path/to/split_on_phones.txt
    ```
 an example [split_phones_file is here](split_on_phones.txt)
@@ -106,13 +106,14 @@ python estimate_midi.py path/to/your/transcriptions.csv path/to/your/wavs
 
 ### 5.1 take apart transcriptions.csv into DS files
 
+Make sure your wave fiels are in a subfodler called "wavs"
 Run:
 
 ```bash
 python convert_ds.py csv2ds path/to/your/transcriptions.csv path/to/your/wavs
 ```
 
-This will generate *.ds files matching your *.wav files in the same directory.
+This will generate *.ds files matching your *.wav files in the "wavs" directory.
 
 ### 5.2 manually edit MIDI sequences
 

--- a/variance-temp-solution/estimate_midi.py
+++ b/variance-temp-solution/estimate_midi.py
@@ -34,7 +34,7 @@ def estimate_midi(
         item: dict
         ph_dur = [float(d) for d in item['ph_dur'].split()]
         ph_num = [int(n) for n in item['ph_num'].split()]
-        assert sum(ph_num) == len(ph_dur), f'ph_num does not sum to number of phones in \'{item["name"]}\'.'
+        assert sum(ph_num) == len(ph_dur), f'ph_num ({sum(ph_num)}) does not sum to number of phones ({len(ph_dur)}) in \'{item["name"]}\'.'
 
         word_dur = []
         i = 0

--- a/variance-temp-solution/requirements.txt
+++ b/variance-temp-solution/requirements.txt
@@ -3,3 +3,4 @@ librosa<0.10.0
 numpy==1.23.5
 praat-parselmouth==0.4.3
 tqdm
+praatio

--- a/variance-temp-solution/split_on_phones.txt
+++ b/variance-temp-solution/split_on_phones.txt
@@ -1,0 +1,16 @@
+aa
+ae
+ah
+ao
+aw
+ay
+eh
+er
+ey
+ih
+iy
+ow
+oy
+uh
+uw
+y

--- a/variance-temp-solution/textgrid_add_ph_num.py
+++ b/variance-temp-solution/textgrid_add_ph_num.py
@@ -2,20 +2,25 @@ import os
 import csv
 from praatio import textgrid
 import click
+import pathlib
 
 # This assumes you used https://github.com/openvpi/DiffSinger/blob/main/pipelines/no_midi_preparation.ipynb to build your transcriptions
 # if you have textgrid files from montreal alignment or labelling that has words and phones in them, this **should** work
 # The no_midi_preperation notebook pipeline adds in random SP at start and end of the textgrid data, this is taken into account but I recommend a manual sanity check after running this
 
+# Usage: python textgrid_add_ph_num.py {PATH TO YOUR transcriptions.csv} --textgrid_dir {textgrids DIRECTORY} --split_phones_file {file PATH}
+
+# You can choose if you want to split on gaps by adding htem into your split_phones_file, eg include SP, pau, AP etc.. 
 
 @click.command(help='Add ph_num attribute into transcriptions.csv')
 @click.argument('transcription_path', metavar='TRANSCRIPTIONS')
+@click.option('--split_phones_file', metavar='FILE', help="Supply a file with phonemes to split phone counts")
 @click.option('--textgrid_dir', metavar='FILE')
 def add_ph_num(
         transcription_path: str = "transcriptions.csv",
-        textgrid_dir: str = "textgrids",
+        textgrid_dir: str = "textgrid",
+        split_phones_file: str = "vowels.txt",
 ):
-def add_ph_num():
 
     transcription_new_path = transcription_path + '.new.csv'
 
@@ -26,28 +31,57 @@ def add_ph_num():
         for item in reader:
             items.append(item)
 
-    for item in items:
-        item: dict
-        if item['name'] and len(item['name']) > 0 :
-            textgrid_file = os.path.join(textgrid_dir, item['name'] + '.TextGrid')
-            ph_num = []
-            if os.path.exists(textgrid_file) :
-                textgrid_data = textgrid.openTextgrid(textgrid_file, True)
-                ph_num = generate_ph_word_num(textgrid_data,item)
-                item['ph_num'] = ' '.join(str(x) for x in ph_num)
-            else:
-                print('>>> NO textgrid',item['name'])
+    split_on_vowel = False
+    split_phones = []
 
-            #final check
-            ph_dur = [float(d) for d in item['ph_dur'].split()]
-            if sum(ph_num) != len(ph_dur):
-                print( f'ph_num {sum(ph_num)} does not sum to number of phones {len(ph_dur)} in {item["name"]}.' )
+    if split_phones_file and len(split_phones_file) > 0 : 
+        try:
+            split_phones_path = pathlib.Path(split_phones_file).resolve()
+        except FileNotFoundError:
+            # doesn't exist
+            print(f'Split phoneme file {split_phones_file} not found')
+        else:
+        # exists
+            with open(split_phones_path, 'r', encoding='utf8') as f:
+                #vowels.update(f.read().split())
+                split_phones = f.read().splitlines()
+            split_using_file = True
+
+    out_data: list[dict] = []
+
+    for item in items:
+
+        if all_silence_check(item['ph_seq'].split()):
+
+            print(f'ERROR: {item["name"]} has all pauses and silences [{item["ph_seq"]}] please manually check - excluding row from data')
+
+        else:
+            item: dict
+
+            if item['name'] and len(item['name']) > 0 :
+                textgrid_file = os.path.join(textgrid_dir, item['name'] + '.TextGrid')
+                ph_num = []
+
+                if os.path.exists(textgrid_file) :
+                    textgrid_data = textgrid.openTextgrid(textgrid_file, True)
+                    print('| Processing ' + item['name'])
+                    ph_num = generate_ph(textgrid_data, item, split_using_file, split_phones)
+                    item['ph_num'] = ' '.join(str(x) for x in ph_num)
+                else:
+                    print(f'| ERROR: No textgrid {item["name"]}')
+
+                #final check
+                ph_dur = [float(d) for d in item['ph_dur'].split()]
+                if sum(ph_num) != len(ph_dur):
+                    print( f'ph_num {sum(ph_num)} does not sum to number of phones {len(ph_dur)} in {item["name"]}.' )
+
+            out_data.append(item)
 
 
     with open(transcription_new_path, 'w', encoding='utf8', newline='') as f:
         writer = csv.DictWriter(f, fieldnames=['name', 'ph_seq', 'ph_dur', 'ph_num'])
         writer.writeheader()
-        writer.writerows(items)
+        writer.writerows(out_data)
 
 def is_joinable_silence(phone_str):
     if phone_str == 'pau' or phone_str == 'SP' or phone_str == 'AS':
@@ -55,10 +89,10 @@ def is_joinable_silence(phone_str):
     else:
         return False
 
-
-          
+         
 # NOTE: The no_midi_preperation notebook pipeline adds in random SP at start and end of the textgrid data
-def generate_ph_word_num(textgrid_data, csv_data):
+# This returns a list (ph_num) containing the number of phonemes
+def generate_ph(textgrid_data, csv_data, split_using_file, split_phones):
     words = textgrid_data.getTier('words').entries
     phones = textgrid_data.getTier('phones').entries
     csv_phones = csv_data['ph_seq'].split()
@@ -70,7 +104,7 @@ def generate_ph_word_num(textgrid_data, csv_data):
         #assuming the missmatch is due to SP at start or end
         num_diff = len(csv_phones) - len(phones)
         if len(csv_phones) > len(phones) and num_diff <= 2:
-            #if num_diff == 1
+
             if csv_phones[0] != phones[0].label and is_joinable_silence(csv_phones[0]) :
                 start_diff = 1
             if csv_phones[-1] != phones[-1].label and is_joinable_silence(csv_phones[-1]) :
@@ -78,7 +112,53 @@ def generate_ph_word_num(textgrid_data, csv_data):
         else:
             print(f'ERROR: {csv_data["name"]} has {len(csv_phones)} phones, but {len(phones)} in the TextGrid file, please manually fix')
 
-    word_ph_nums = []
+    if split_using_file:
+
+        ph_num = generate_ph_vowel_num(words,phones,split_phones)
+    else:
+        ph_num = generate_ph_word_num(words,phones)
+
+    #add in any differneces between the csv and the TextGrid data
+    if start_diff > 0:
+        ph_num[0] += start_diff
+    if end_diff > 0:
+        ph_num[-1] += end_diff
+
+    return ph_num
+
+# NOTE: The no_midi_preperation notebook pipeline adds in random SP at start and end of the textgrid data
+# This returns a list (ph_num) containing the number of phonemes , split by vowel and word starts 
+
+# In singing, vowels, instead of consonants, are used to align with the beginnings of notes. 
+# For this reason, each word should start with a vowel/AP/SP, and end with leading consonant(s) of the next word (if there are any). 
+# See the example below:
+# 
+# text      |   AP   |     shi     |        zhe       |  => word transcriptions (pinyin, romaji, etc.)
+# ph_seq    |   AP   |  sh  |  ir  | zh |      e      |  => phoneme sequence
+# ph_num    |       2       |     2     |      1      |  => word-level phoneme division
+# 
+# where sh and zh are consonants, AP, ir and e can be regarded as vowels. There are one special case that a word can start with a consonants: isolated consonants. In this case, all phones in the word are consonants.
+def generate_ph_vowel_num(words, phones, split_phones):
+
+    ph_num = []
+    phone_index = 0
+    phone_count = 0
+    ph_labels = []
+    vowel_index = []
+    skip_next = False
+
+    # each "syllable" gets split by phonemes in split_phones
+    for phone in phones:
+        phone_count += 1
+        ph_labels.append(phone.label)
+        if phone.label in split_phones:
+            ph_num.append(phone_count)
+            phone_count = 0
+    
+    return ph_num
+
+
+def generate_ph_word_num(words, phones):
     ph_num = []
     # force_increment is used to track pau,SP,AS
 
@@ -106,13 +186,21 @@ def generate_ph_word_num(textgrid_data, csv_data):
     #if we exit the loop on a pause we need to add it in
     if force_increment > 0:
         ph_num.append(force_increment)
-
-    #add in any differneces between the csv and the TextGrid data
-    if start_diff > 0:
-        ph_num[0] += start_diff
-    if end_diff > 0:
-        ph_num[-1] += end_diff
+    
     return ph_num
+
+def all_silence_check(phones):
+    silence_markers = ['pau','spn','SP','AS']
+    silence_num = 0
+    phones_num = 0
+    for phone in phones:
+        phones_num += 1
+        if phone in silence_markers:
+            silence_num += 1
+    if phones_num == silence_num:
+        return True
+    
+    return False
 
 if __name__ == '__main__':
     add_ph_num()

--- a/variance-temp-solution/textgrid_add_ph_num.py
+++ b/variance-temp-solution/textgrid_add_ph_num.py
@@ -73,7 +73,14 @@ def add_ph_num(
                 #final check
                 ph_dur = [float(d) for d in item['ph_dur'].split()]
                 if sum(ph_num) != len(ph_dur):
-                    print( f'ph_num {sum(ph_num)} does not sum to number of phones {len(ph_dur)} in {item["name"]}.' )
+                    print( f'  ph_num {sum(ph_num)} does not sum to number of phones {len(ph_dur)} in {item["name"]}.' )
+                    print( f'csv_____: {item["ph_seq"]}')
+                    errphones = textgrid_data.getTier('phones').entries
+                    tgphones = []
+                    for tg_phone in errphones:
+                        tgphones.append(tg_phone.label)
+                    print( f'textgrid: {" ".join(tgphones)}')
+
 
             out_data.append(item)
 
@@ -84,7 +91,7 @@ def add_ph_num(
         writer.writerows(out_data)
 
 def is_joinable_silence(phone_str):
-    if phone_str == 'pau' or phone_str == 'SP' or phone_str == 'AS':
+    if phone_str in ['pau','SP','AS']:
         return True
     else:
         return False
@@ -118,12 +125,14 @@ def generate_ph(textgrid_data, csv_data, split_using_file, split_phones):
     else:
         ph_num = generate_ph_word_num(words,phones)
 
+#    print(f' Adding in [{start_diff}] at start and [{end_diff}] at end')
+#    print(" ".join(map(str,ph_num)))
     #add in any differneces between the csv and the TextGrid data
     if start_diff > 0:
         ph_num[0] += start_diff
     if end_diff > 0:
         ph_num[-1] += end_diff
-
+#    print(" ".join(map(str,ph_num)))
     return ph_num
 
 # NOTE: The no_midi_preperation notebook pipeline adds in random SP at start and end of the textgrid data
@@ -139,22 +148,27 @@ def generate_ph(textgrid_data, csv_data, split_using_file, split_phones):
 # 
 # where sh and zh are consonants, AP, ir and e can be regarded as vowels. There are one special case that a word can start with a consonants: isolated consonants. In this case, all phones in the word are consonants.
 def generate_ph_vowel_num(words, phones, split_phones):
-
+#    print('VOWELS')
     ph_num = []
     phone_index = 0
     phone_count = 0
     ph_labels = []
     vowel_index = []
-    skip_next = False
+    appended = False
+
 
     # each "syllable" gets split by phonemes in split_phones
     for phone in phones:
+        appended = False
         phone_count += 1
         ph_labels.append(phone.label)
         if phone.label in split_phones:
             ph_num.append(phone_count)
             phone_count = 0
-    
+            appended = True
+
+    if(not appended and phone_count > 0):
+        ph_num.append(phone_count)
     return ph_num
 
 

--- a/variance-temp-solution/textgrid_add_ph_num.py
+++ b/variance-temp-solution/textgrid_add_ph_num.py
@@ -1,0 +1,118 @@
+import os
+import csv
+from praatio import textgrid
+import click
+
+# This assumes you used https://github.com/openvpi/DiffSinger/blob/main/pipelines/no_midi_preparation.ipynb to build your transcriptions
+# if you have textgrid files from montreal alignment or labelling that has words and phones in them, this **should** work
+# The no_midi_preperation notebook pipeline adds in random SP at start and end of the textgrid data, this is taken into account but I recommend a manual sanity check after running this
+
+
+@click.command(help='Add ph_num attribute into transcriptions.csv')
+@click.argument('transcription_path', metavar='TRANSCRIPTIONS')
+@click.option('--textgrid_dir', metavar='FILE')
+def add_ph_num(
+        transcription_path: str = "transcriptions.csv",
+        textgrid_dir: str = "textgrids",
+):
+def add_ph_num():
+
+    transcription_new_path = transcription_path + '.new.csv'
+
+    #open csv and textgrid files
+    items: list[dict] = []
+    with open(transcription_path, 'r', encoding='utf8') as f:
+        reader = csv.DictReader(f)
+        for item in reader:
+            items.append(item)
+
+    for item in items:
+        item: dict
+        if item['name'] and len(item['name']) > 0 :
+            textgrid_file = os.path.join(textgrid_dir, item['name'] + '.TextGrid')
+            ph_num = []
+            if os.path.exists(textgrid_file) :
+                textgrid_data = textgrid.openTextgrid(textgrid_file, True)
+                ph_num = generate_ph_word_num(textgrid_data,item)
+                item['ph_num'] = ' '.join(str(x) for x in ph_num)
+            else:
+                print('>>> NO textgrid',item['name'])
+
+            #final check
+            ph_dur = [float(d) for d in item['ph_dur'].split()]
+            if sum(ph_num) != len(ph_dur):
+                print( f'ph_num {sum(ph_num)} does not sum to number of phones {len(ph_dur)} in {item["name"]}.' )
+
+
+    with open(transcription_new_path, 'w', encoding='utf8', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=['name', 'ph_seq', 'ph_dur', 'ph_num'])
+        writer.writeheader()
+        writer.writerows(items)
+
+def is_joinable_silence(phone_str):
+    if phone_str == 'pau' or phone_str == 'SP' or phone_str == 'AS':
+        return True
+    else:
+        return False
+
+
+          
+# NOTE: The no_midi_preperation notebook pipeline adds in random SP at start and end of the textgrid data
+def generate_ph_word_num(textgrid_data, csv_data):
+    words = textgrid_data.getTier('words').entries
+    phones = textgrid_data.getTier('phones').entries
+    csv_phones = csv_data['ph_seq'].split()
+
+    start_diff = 0
+    end_diff = 0
+
+    if len(phones) != len(csv_phones) :
+        #assuming the missmatch is due to SP at start or end
+        num_diff = len(csv_phones) - len(phones)
+        if len(csv_phones) > len(phones) and num_diff <= 2:
+            #if num_diff == 1
+            if csv_phones[0] != phones[0].label and is_joinable_silence(csv_phones[0]) :
+                start_diff = 1
+            if csv_phones[-1] != phones[-1].label and is_joinable_silence(csv_phones[-1]) :
+                end_diff = 1
+        else:
+            print(f'ERROR: {csv_data["name"]} has {len(csv_phones)} phones, but {len(phones)} in the TextGrid file, please manually fix')
+
+    word_ph_nums = []
+    ph_num = []
+    # force_increment is used to track pau,SP,AS
+
+    force_increment = 0 
+    # assumption: the order of entries never changes and it the same sequence as in the textgrid file
+    for word in words:
+
+        num_phones_in_word = 0
+        # force_increment is set by the last word if it was a silence
+        for phone in phones:
+            if word.start <= phone.start < word.end :
+                num_phones_in_word += 1
+
+        num_recorded = num_phones_in_word
+        
+        #reset for each word, unless its a pause - if the word is a pause we will "add" +1 to the next word's phone count
+        if not word.label or word.label == '' or word.label == '' :
+            force_increment += 1
+        else:
+            if force_increment > 0 :
+                num_recorded += force_increment
+                force_increment = 0
+            ph_num.append(num_recorded)
+    
+    #if we exit the loop on a pause we need to add it in
+    if force_increment > 0:
+        ph_num.append(force_increment)
+
+    #add in any differneces between the csv and the TextGrid data
+    if start_diff > 0:
+        ph_num[0] += start_diff
+    if end_diff > 0:
+        ph_num[-1] += end_diff
+    return ph_num
+
+if __name__ == '__main__':
+    add_ph_num()


### PR DESCRIPTION
This is an alternative way for generating the ph_num using textgrids for polysyllabic phoneme systems (English, Russian, etc.). If a user has used the pipelines/no_midi_preparation.ipynb and has created the textgrids already.