### PR TITLE
Several patches and features to a few scripts

### DIFF
--- a/acoustic_forced_alignment/README.md
+++ b/acoustic_forced_alignment/README.md
@@ -81,6 +81,8 @@ MFA fails on some platforms if the WAVs are not in 16kHz 16bit PCM format. The f
 python reformat_wavs.py --src path/to/your/segments/ --dst path/to/tmp/dir/
 ```
 
+NOTE: `--normalize` can be added to normalize the audio files with respect to the peak value of the whole segments. This is especially helpful on aspiration detection during TextGrid enhancement if the original segments are too quite.
+
 ### 3.2 Run MFA on the corpus
 
 MFA will align your labels to your recordings and save the results to TextGrid files.
@@ -138,7 +140,29 @@ Run:
 python build_dataset.py --wavs path/to/your/segments/ --tg path/to/final/textgrids/ --dataset path/to/your/dataset/
 ```
 
-NOTE: this will insert random silence parts around each segments by default for better `SP` stability. If you do not need these silence parts, please use the `--skip_silence_insertion` option.
+NOTE 1: This will insert random silence parts around each segments by default for better `SP` stability. If you do not need these silence parts, please use the `--skip_silence_insertion` option.
+
+NOTE 2: `--wav_subtype` can be used to specify the bit-depth of the saved WAV files. Options are `PCM_16` (default), `PCM_24`, `PCM_32`, `FLOAT`, and `DOUBLE`.
 
 After doing all things above, you should put it into data/ of the DiffSinger main repository. Now, your dataset can be used to train DiffSinger acoustic models. If you want to train DiffSinger variance models, please follow this [instructions](../variance-temp-solution/README.md).
 
+
+## 5. Write configuration file
+
+Copy the template configration file from `configs/templates` in the DiffSinger repository to your data folder, or a new folder if working with multi-speaker model. Specify required fields in the configurations, check `DiffSinger/docs/ConfigurationSchemas.md` for help on the meanings of those fields.
+
+For automatic validation set selection, you can leave the following field as empty. If the field is not empty, the script will prompt a overwrite confirmation later.
+```yaml
+...
+test_prefixes:
+...
+```
+
+And run:
+```bash
+python select_test_set.py path/to/your/config.yaml [--rel_path <PATH>]
+```
+
+NOTE 1: `--rel_path` is probably necessary if there are relative paths in your config file. If only absolute paths exist in it, you can omit this argument.
+
+NOTE 2: There are other useful arguments of this script. You can use them to change the total number of validation samples.

--- a/acoustic_forced_alignment/build_dataset.py
+++ b/acoustic_forced_alignment/build_dataset.py
@@ -11,12 +11,14 @@ from textgrid import TextGrid
 
 
 @click.command(help='Collect phoneme alignments into transcriptions.csv')
-@click.option('--wavs', help='Path to the segments directory')
-@click.option('--tg', help='Path to the final TextGrids directory')
-@click.option('--dataset', help='Path to transcriptions.csv')
+@click.option('--wavs', required=True, help='Path to the segments directory')
+@click.option('--tg', required=True, help='Path to the final TextGrids directory')
+@click.option('--dataset', required=True, help='Path to transcriptions.csv')
 @click.option('--skip_silence_insertion', is_flag=True, show_default=True,
               help='Do not insert silence around segments')
-def build_dataset(wavs, tg, dataset, skip_silence_insertion):
+@click.option('--wav_subtype', default="PCM_16", show_default=True,
+              help='WAV subtype')
+def build_dataset(wavs, tg, dataset, skip_silence_insertion, wav_subtype):
     wavs = pathlib.Path(wavs)
     tg_dir = pathlib.Path(tg)
     del tg
@@ -55,7 +57,7 @@ def build_dataset(wavs, tg, dataset, skip_silence_insertion):
                     ph_dur.append(len_sil / samplerate)
         ph_seq = ' '.join(ph_seq)
         ph_dur = ' '.join([str(round(d, 6)) for d in ph_dur])
-        soundfile.write(dataset / 'wavs' / wavfile.name, y, samplerate)
+        soundfile.write(dataset / 'wavs' / wavfile.name, y, samplerate, subtype=wav_subtype)
         transcriptions.append({'name': wavfile.stem, 'ph_seq': ph_seq, 'ph_dur': ph_dur})
 
     with open(dataset / 'transcriptions.csv', 'w', encoding='utf8', newline='') as f:

--- a/acoustic_forced_alignment/select_test_set.py
+++ b/acoustic_forced_alignment/select_test_set.py
@@ -1,0 +1,81 @@
+import csv
+import random
+from collections import defaultdict
+from pathlib import Path
+
+import click
+import yaml
+
+
+# noinspection PyShadowingBuiltins
+@click.command(help='Randomly select test samples')
+@click.argument(
+    'config',
+    type=click.Path(file_okay=True, dir_okay=False, resolve_path=True, writable=True, path_type=Path),
+    metavar="CONFIG"
+)
+@click.option(
+    '--rel_path',
+    type=click.Path(file_okay=False, dir_okay=True, resolve_path=True, path_type=Path),
+    default=Path('.'),
+    help='Path that is relative to the paths mentioned in the config file.'
+)
+def select_test_set(config, rel_path):
+    with open(config, 'r', encoding='utf8') as f:
+        hparams = yaml.safe_load(f)
+
+    spk_map = None
+    spk_ids = hparams['spk_ids']
+    speakers = hparams['speakers']
+    raw_data_dirs = hparams['raw_data_dir']
+    assert isinstance(speakers, list), 'Speakers must be a list'
+    assert len(speakers) == len(raw_data_dirs), \
+        'Number of raw data dirs must equal number of speaker names!'
+    if not spk_ids:
+        spk_ids = list(range(len(raw_data_dirs)))
+    else:
+        assert len(spk_ids) == len(raw_data_dirs), \
+            'Length of explicitly given spk_ids must equal the number of raw datasets.'
+    assert max(spk_ids) < hparams['num_spk'], \
+        f'Index in spk_id sequence {spk_ids} is out of range. All values should be smaller than num_spk.'
+
+    spk_map = {}
+    path_spk_map = defaultdict(list)
+    for ds_id, (spk_name, raw_path, spk_id) in enumerate(zip(speakers, raw_data_dirs, spk_ids)):
+        if spk_name in spk_map and spk_map[spk_name] != spk_id:
+            raise ValueError(f'Invalid speaker ID assignment. Name \'{spk_name}\' is assigned '
+                                f'with different speaker IDs: {spk_map[spk_name]} and {spk_id}.')
+        spk_map[spk_name] = spk_id
+        path_spk_map[spk_id].append((ds_id, rel_path / raw_path))
+
+    training_cases = []
+    for spk_raw_dirs in path_spk_map.values():
+        training_case = []
+        # training cases from the same speaker are grouped together
+        for ds_id, raw_data_dir in spk_raw_dirs:
+            with open(raw_data_dir / 'transcriptions.csv', 'r', encoding='utf8') as f:
+                reader = csv.DictReader(f)
+                for row in reader:
+                    if (raw_data_dir / 'wavs' / f'{row["name"]}.wav').exists():
+                        training_case.append(f'{ds_id}:{row["name"]}')
+        training_cases.append(training_case)
+
+    test_prefixes = []
+    total = min(20, max(10, 4 * len(training_cases)))
+    quotient, remainder = total // len(training_cases), total % len(training_cases)
+    if quotient == 0:
+        test_counts = [1] * len(training_cases)
+    else:
+        test_counts = [quotient + 1] * remainder + [quotient] * (len(training_cases) - remainder)
+    for i, count in enumerate(test_counts):
+        test_prefixes += sorted(random.sample(training_cases[i], count))
+    if not hparams['test_prefixes'] or click.confirm('Overwrite existing test prefixes?', abort=False):
+        hparams['test_prefixes'] = test_prefixes
+        with open(config, 'w', encoding='utf8') as f:
+            yaml.dump(hparams, f, sort_keys=False)
+        print('Test prefixes saved.')
+    else:
+        print('Test prefixes not saved, aborted.')
+
+if __name__ == '__main__':
+    select_test_set()

--- a/acoustic_forced_alignment/select_test_set.py
+++ b/acoustic_forced_alignment/select_test_set.py
@@ -16,8 +16,8 @@ import yaml
 )
 @click.option(
     '--rel_path',
-    required=True,
     type=click.Path(file_okay=False, dir_okay=True, resolve_path=True, path_type=Path),
+    default=None,
     help='Path that is relative to the paths mentioned in the config file.'
 )
 @click.option(
@@ -49,7 +49,7 @@ def select_test_set(config, rel_path, _min, _max, per_speaker):
     spk_map = None
     spk_ids = hparams['spk_ids']
     speakers = hparams['speakers']
-    raw_data_dirs = hparams['raw_data_dir']
+    raw_data_dirs = list(map(Path, hparams['raw_data_dir']))
     assert isinstance(speakers, list), 'Speakers must be a list'
     assert len(speakers) == len(raw_data_dirs), \
         'Number of raw data dirs must equal number of speaker names!'
@@ -68,7 +68,7 @@ def select_test_set(config, rel_path, _min, _max, per_speaker):
             raise ValueError(f'Invalid speaker ID assignment. Name \'{spk_name}\' is assigned '
                                 f'with different speaker IDs: {spk_map[spk_name]} and {spk_id}.')
         spk_map[spk_name] = spk_id
-        path_spk_map[spk_id].append((ds_id, rel_path / raw_path))
+        path_spk_map[spk_id].append((ds_id, rel_path / raw_path if rel_path else raw_path))
 
     training_cases = []
     for spk_raw_dirs in path_spk_map.values():

--- a/acoustic_forced_alignment/select_test_set.py
+++ b/acoustic_forced_alignment/select_test_set.py
@@ -93,6 +93,7 @@ def select_test_set(config, rel_path, _min, _max, per_speaker):
         test_prefixes += sorted(random.sample(training_cases[i], count))
     if not hparams['test_prefixes'] or click.confirm('Overwrite existing test prefixes?', abort=False):
         hparams['test_prefixes'] = test_prefixes
+        hparams['num_valid_plots'] = len(test_prefixes)
         with open(config, 'w', encoding='utf8') as f:
             yaml.dump(hparams, f, sort_keys=False)
         print('Test prefixes saved.')

--- a/acoustic_forced_alignment/select_test_set.py
+++ b/acoustic_forced_alignment/select_test_set.py
@@ -16,11 +16,33 @@ import yaml
 )
 @click.option(
     '--rel_path',
+    required=True,
     type=click.Path(file_okay=False, dir_okay=True, resolve_path=True, path_type=Path),
-    default=Path('.'),
     help='Path that is relative to the paths mentioned in the config file.'
 )
-def select_test_set(config, rel_path):
+@click.option(
+    '--min', '_min',
+    show_default=True,
+    type=click.IntRange(min=1),
+    default=10,
+    help='Minimum number of test samples.'
+)
+@click.option(
+    '--max', '_max',
+    show_default=True,
+    type=click.IntRange(min=1),
+    default=20,
+    help='Maximum number of test samples (note that each speaker will have at least one test sample).'
+)
+@click.option(
+    '--per_speaker',
+    show_default=True,
+    type=click.IntRange(min=1),
+    default=4,
+    help='Expected number of test samples per speaker.'
+)
+def select_test_set(config, rel_path, _min, _max, per_speaker):
+    assert _min <= _max, 'min must be smaller or equal to max'
     with open(config, 'r', encoding='utf8') as f:
         hparams = yaml.safe_load(f)
 
@@ -61,7 +83,7 @@ def select_test_set(config, rel_path):
         training_cases.append(training_case)
 
     test_prefixes = []
-    total = min(20, max(10, 4 * len(training_cases)))
+    total = min(_max, max(_min, per_speaker * len(training_cases)))
     quotient, remainder = total // len(training_cases), total % len(training_cases)
     if quotient == 0:
         test_counts = [1] * len(training_cases)

--- a/variance-temp-solution/README.md
+++ b/variance-temp-solution/README.md
@@ -118,6 +118,8 @@ This will generate a new transcriptions.csv from the DS files you just edited. A
 
 Now the transcriptions.csv can be used for all functionalities of DiffSinger training.
 
+`convert_ds.py ds2csv` supports DS files which have no corresponding WAV files. All sentences in these files will be assigned a virtual item name, and inserted into the transcriptions. This is a preparation to support using DS tuning projects to train a variance model. In addition, `curves.json` file is written to support `f0` sequence refinement.
+
 ## (Appendix) other useful tools
 
 ### RMVPE pitch extraction algorithm

--- a/variance-temp-solution/convert_ds.py
+++ b/variance-temp-solution/convert_ds.py
@@ -3,6 +3,7 @@ import json
 import pathlib
 from decimal import Decimal
 from math import isclose
+import uuid
 
 import click
 import librosa
@@ -37,7 +38,9 @@ def try_resolve_note_slur_by_matching(ph_dur, ph_num, note_dur, tol):
             new_note_dur.append(note_pos[idx_note])
             idx_note += 1
             slur = True
-    return np.diff(new_note_dur, prepend=Decimal("0.0")).tolist(), note_slur
+    ret_note_dur = np.diff(new_note_dur, prepend=Decimal("0.0")).tolist()
+    assert len(ret_note_dur) == len(note_slur)
+    return ret_note_dur, note_slur
 
 
 def try_resolve_slur_by_slicing(ph_dur, ph_num, note_seq, note_dur, tol):
@@ -75,7 +78,9 @@ def try_resolve_slur_by_slicing(ph_dur, ph_num, note_seq, note_dur, tol):
                     new_note_dur.append(word_pos[idx_word])
                     note_slur.append(1 if slur else 0)
         idx_word += 1
-    return new_note_seq, np.diff(new_note_dur, prepend=Decimal("0.0")).tolist(), note_slur
+    ret_note_dur = np.diff(new_note_dur, prepend=Decimal("0.0")).tolist()
+    assert len(new_note_seq) == len(ret_note_dur) == len(note_slur)
+    return new_note_seq, ret_note_dur, note_slur
 
 
 @click.group()
@@ -110,7 +115,7 @@ def cli():
 )
 @click.option("--hop_size", "-h", type=int, default=512, help="Hop size for f0_seq", metavar="INT")
 @click.option("--sample_rate", "-s", type=int, default=44100, help="Sample rate of audio", metavar="INT")
-@click.option("--pe", type=str, default="parselmouth", help='Pitch extractor (parselmouth, rmvpe)', metavar="ALGORITHM")
+@click.option("--pe", type=str, default="parselmouth", help="Pitch extractor (parselmouth, rmvpe)", metavar="ALGORITHM")
 def csv2ds(transcription_file, wavs_folder, tolerance, hop_size, sample_rate, pe):
     """Convert a transcription file to DS file"""
     assert wavs_folder.is_dir(), "wavs folder not found."
@@ -141,7 +146,7 @@ def csv2ds(transcription_file, wavs_folder, tolerance, hop_size, sample_rate, pe
                         ph_dur, ph_num, note_dur, tolerance
                     )
                 except ValueError:
-                    # logging.warning(f'note_slur is not resolved by matching for {item_name}')
+                    # logging.warning(f"note_slur is not resolved by matching for {item_name}")
                     note_seq, note_dur, note_slur = try_resolve_slur_by_slicing(
                         ph_dur, ph_num, note_seq, note_dur, tolerance
                     )
@@ -175,7 +180,7 @@ def csv2ds(transcription_file, wavs_folder, tolerance, hop_size, sample_rate, pe
         click.echo("Aborted.")
 
 
-@click.command(help="Convert DS files to a transcription file")
+@click.command(help="Convert DS files to a transcription and curve files")
 @click.argument(
     "ds_folder",
     type=click.Path(file_okay=False, resolve_path=True, exists=True, path_type=pathlib.Path),
@@ -186,6 +191,13 @@ def csv2ds(transcription_file, wavs_folder, tolerance, hop_size, sample_rate, pe
     type=click.Path(file_okay=True, dir_okay=False, resolve_path=True, path_type=pathlib.Path),
     metavar="TRANSCRIPTIONS",
 )
+@click.argument(
+    "curve_file",
+    type=str,
+    required=False,
+    default=None,
+    metavar="CURVES",
+)
 @click.option(
     "--overwrite",
     "-f",
@@ -193,28 +205,66 @@ def csv2ds(transcription_file, wavs_folder, tolerance, hop_size, sample_rate, pe
     default=False,
     help="Overwrite existing transcription file",
 )
-def ds2csv(ds_folder, transcription_file, overwrite):
+def ds2csv(ds_folder, transcription_file, curve_file, overwrite):
     """Convert DS files to a transcription file"""
-    if not overwrite and transcription_file.is_file():
-        raise FileExistsError(f"{transcription_file} already exists.")
-    from glob import glob
+    if curve_file is None:
+        curve_file = transcription_file.parent / "curves.json"
+    else:
+        curve_file = pathlib.Path(curve_file)
+    if not overwrite and (transcription_file.exists() or curve_file.exists()):
+        raise FileExistsError(f"{transcription_file} or {curve_file} already exist.")
 
     transcriptions = []
-    for fn in tqdm(glob(str(ds_folder / "*.ds")), ncols=80):
-        fp = pathlib.Path(fn)
-        with open(fp, "r", encoding="utf-8") as f:
-            ds = json.load(f)
-            transcriptions.append(
-                {
-                    "name": fp.stem,
-                    "ph_seq": ds[0]["ph_seq"],
-                    "ph_dur": ds[0]["ph_dur"],
-                    "ph_num": ds[0]["ph_num"],
-                    "note_seq": ds[0]["note_seq"],
-                    "note_dur": ds[0]["note_dur"],
-                    # "note_slur": ds[0]["note_slur"],
+    curves = {}
+    # records that have corresponding wav files, assuming it's midi annotation
+    for fp in tqdm(ds_folder.glob("*.ds"), ncols=80):
+        if fp.with_suffix(".wav").exists():
+            with open(fp, "r", encoding="utf-8") as f:
+                ds = json.load(f)
+                transcriptions.append(
+                    {
+                        "name": fp.stem,
+                        "ph_seq": ds[0]["ph_seq"],
+                        "ph_dur": ds[0]["ph_dur"],
+                        "ph_num": ds[0]["ph_num"],
+                        "note_seq": ds[0]["note_seq"],
+                        "note_dur": ds[0]["note_dur"],
+                        # "note_slur": ds[0]["note_slur"],
+                    }
+                )
+                assert fp.stem not in curves, f"{fp.stem} already exists in curves."
+                curves[fp.stem] = {
+                    "f0_seq": ds[0]["f0_seq"],
+                    "f0_timestep": float(ds[0]["f0_timestep"])
                 }
-            )
+    # Lone DS files.
+    for fp in tqdm(ds_folder.glob("*.ds"), ncols=80):
+        if not fp.with_suffix(".wav").exists():
+            with open(fp, "r", encoding="utf-8") as f:
+                ds = json.load(f)
+                for sub_ds in ds:
+                    item_name = fp.stem + "_" + uuid.uuid4().hex[:3]
+                    for _ in range(10):
+                        if item_name not in curves:
+                            break
+                        item_name = fp.stem + "_" + uuid.uuid4().hex[:3]
+                    else:
+                        raise ValueError(f"Failed to generate a unique item name for {fp.stem}")
+                    transcriptions.append(
+                        {
+                            "name": item_name,
+                            "ph_seq": sub_ds["ph_seq"],
+                            "ph_dur": sub_ds["ph_dur"],
+                            "ph_num": sub_ds["ph_num"],
+                            "note_seq": sub_ds["note_seq"],
+                            "note_dur": sub_ds["note_dur"],
+                            # "note_slur": sub_ds["note_slur"],
+                        }
+                    )
+                    curves[item_name] = {
+                        "f0_seq": sub_ds["f0_seq"],
+                        "f0_timestep": float(sub_ds["f0_timestep"])
+                    }
     with open(transcription_file, "w", newline="", encoding="utf-8") as f:
         writer = csv.DictWriter(
             f,
@@ -230,6 +280,8 @@ def ds2csv(ds_folder, transcription_file, overwrite):
         )
         writer.writeheader()
         writer.writerows(transcriptions)
+    with open(curve_file, "w", encoding="utf-8") as f:
+        json.dump(curves, f, ensure_ascii=False, indent=4)
 
 
 cli.add_command(csv2ds)

--- a/variance-temp-solution/convert_ds.py
+++ b/variance-temp-solution/convert_ds.py
@@ -109,7 +109,7 @@ def cli():
     "--tolerance",
     "-t",
     type=float,
-    default=0.001,
+    default=0.005,
     help="Tolerance for ph_dur/note_dur mismatch",
     metavar="FLOAT",
 )
@@ -160,10 +160,10 @@ def csv2ds(transcription_file, wavs_folder, tolerance, hop_size, sample_rate, pe
                     "offset": 0.0,
                     "text": trans_line["ph_seq"],
                     "ph_seq": trans_line["ph_seq"],
-                    "ph_dur": trans_line["ph_dur"],
+                    "ph_dur": " ".join(str(round(d, 6)) for d in ph_dur),
                     "ph_num": trans_line["ph_num"],
                     "note_seq": " ".join(note_seq),
-                    "note_dur": " ".join(map(str, note_dur)),
+                    "note_dur": " ".join(str(round(d, 6)) for d in note_dur),
                     "note_slur": " ".join(map(str, note_slur)),
                     "f0_seq": " ".join(map("{:.1f}".format, f0)),
                     "f0_timestep": str(f0_timestep),
@@ -225,16 +225,16 @@ def ds2csv(ds_folder, transcription_file, curve_file, overwrite):
                     {
                         "name": fp.stem,
                         "ph_seq": ds[0]["ph_seq"],
-                        "ph_dur": ds[0]["ph_dur"],
+                        "ph_dur": " ".join(str(round(Decimal(d), 6)) for d in ds[0]["ph_dur"].split()),
                         "ph_num": ds[0]["ph_num"],
                         "note_seq": ds[0]["note_seq"],
-                        "note_dur": ds[0]["note_dur"],
+                        "note_dur": " ".join(str(round(Decimal(d), 6)) for d in ds[0]["note_dur"].split()),
                         # "note_slur": ds[0]["note_slur"],
                     }
                 )
                 assert fp.stem not in curves, f"{fp.stem} already exists in curves."
                 curves[fp.stem] = {
-                    "f0_seq": ds[0]["f0_seq"],
+                    "f0_seq": " ".join(str(round(Decimal(d), 1)) for d in ds[0]["f0_seq"].split()),
                     "f0_timestep": float(ds[0]["f0_timestep"])
                 }
     # Lone DS files.
@@ -254,15 +254,15 @@ def ds2csv(ds_folder, transcription_file, curve_file, overwrite):
                         {
                             "name": item_name,
                             "ph_seq": sub_ds["ph_seq"],
-                            "ph_dur": sub_ds["ph_dur"],
+                            "ph_dur": " ".join(str(round(Decimal(d), 6)) for d in sub_ds["ph_dur"].split()),
                             "ph_num": sub_ds["ph_num"],
                             "note_seq": sub_ds["note_seq"],
-                            "note_dur": sub_ds["note_dur"],
+                            "note_dur": " ".join(str(round(Decimal(d), 6)) for d in sub_ds["note_dur"].split()),
                             # "note_slur": sub_ds["note_slur"],
                         }
                     )
                     curves[item_name] = {
-                        "f0_seq": sub_ds["f0_seq"],
+                        "f0_seq": " ".join(str(round(Decimal(d), 1)) for d in sub_ds["f0_seq"].split()),
                         "f0_timestep": float(sub_ds["f0_timestep"])
                     }
     with open(transcription_file, "w", newline="", encoding="utf-8") as f:

--- a/variance-temp-solution/eliminate_short.py
+++ b/variance-temp-solution/eliminate_short.py
@@ -80,7 +80,7 @@ def eliminate_short(
                 note_dur_new += [n[1] for n in word_note_seq]
                 note_slur_new += [pos > 0 for pos in range(len(word_note_seq))]
             param['note_seq'] = ' '.join(note_seq_new)
-            param['note_dur'] = ' '.join(str(d) for d in note_dur_new)
+            param['note_dur'] = ' '.join(str(round(d, 6)) for d in note_dur_new)
             param['note_slur'] = ' '.join(str(int(s)) for s in note_slur_new)
 
         with open(ds, 'w', encoding='utf8') as f:

--- a/variance-temp-solution/estimate_midi.py
+++ b/variance-temp-solution/estimate_midi.py
@@ -76,7 +76,7 @@ def estimate_midi(
             start = end
 
         item['note_seq'] = ' '.join(note_seq)
-        item['note_dur'] = ' '.join([str(d) for d in note_dur])
+        item['note_dur'] = ' '.join([str(round(d, 6)) for d in note_dur])
 
     with open(transcriptions, 'w', encoding='utf8', newline='') as f:
         writer = csv.DictWriter(f, fieldnames=['name', 'ph_seq', 'ph_dur', 'ph_num', 'note_seq', 'note_dur'])


### PR DESCRIPTION
1. Make several options required, and added the WAV subtype option for `build_dataset.py`
2. Added `--normalize` flag to `reformat_wavs.py`, which will scan the segments, and perform normalization. Prevent low LUFS datasets from having problems with MFA and TextGrid enhancement. (The scan is necessary because relative loudness needs to be preserved).
3. Support dictionaries such as English dictionary in `enhance_tg.py`
4. New script that writes out `test_prefixes` given a `config.yaml`
5. `convert_ds.py ds2csv` now supports the conversion of DS files without corresponding WAV files, and allow multiple sentences in such files. A new JSON file (default to curves.json) will be written alongside transcriptions, and contains `f0_seq` and `f0_timestep`.