### PR TITLE
兼容SOFA直出的transcriptions.csv

### DIFF
--- a/variance-temp-solution/add_ph_num.py
+++ b/variance-temp-solution/add_ph_num.py
@@ -71,7 +71,7 @@ def add_ph_num(
         item['ph_num'] = ' '.join(ph_num)
 
     with open(transcription, 'w', encoding='utf8', newline='') as f:
-        writer = csv.DictWriter(f, fieldnames=['name', 'ph_seq', 'ph_dur', 'ph_num'])
+        writer = csv.DictWriter(f, fieldnames=items[0].keys())
         writer.writeheader()
         writer.writerows(items)
 


### PR DESCRIPTION
对于原先的代码，如果输入的transcriptions.csv的columns包含除了name、ph_seq、ph_dur以外的其他column，那么add_ph_num会报错。sofa直出的transcriptions.csv带有word_seq与word_dur，不能直接使用，比较麻烦。

此pr改了一行代码，可以兼容带有各种columns、各种顺序columns的transcriptions.csv。